### PR TITLE
Fixed a typo in the Step4 notebook

### DIFF
--- a/lessons/05_Step_4.ipynb
+++ b/lessons/05_Step_4.ipynb
@@ -439,8 +439,8 @@
     "    for i in range(1, nx-1):\n",
     "        u[i] = un[i] - un[i] * dt/dx *(un[i] - un[i-1]) + nu*dt/dx**2*\\\n",
     "                (un[i+1]-2*un[i]+un[i-1])\n",
-    "    u[0] = un[0] - un[0] * dt/dx * (un[0] - un[-2]) + nu*dt/dx**2*\\\n",
-    "                (un[1]-2*un[0]+un[-2])\n",
+    "    u[0] = un[0] - un[0] * dt/dx * (un[0] - un[-1]) + nu*dt/dx**2*\\\n",
+    "                (un[1]-2*un[0]+un[-1])\n",
     "    u[-1] = un[-1] - un[-1] * dt/dx * (un[-1] - un[-2]) + nu*dt/dx**2*\\\n",
     "                (un[0]-2*un[-1]+un[-2])\n",
     "        \n",
@@ -616,7 +616,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The `u[0]` calculation had terms that were `un[-2]` in both spatial derivatives. Those should be `un[-1]`.

Additionally it is worth noting that the periodic conditions can all be handled correctly by the `u[i]` calculation as written by simply changing the range to `for i in range(-1, nx-1)` as below. This makes use of python negative indexing which wraps to the end of the array, effectively computing `u[-1]` and `u[0]` first.

```
for n in range(nt):
    un = u.copy()
    for i in range(-1, nx-1):
        u[i] = un[i] - un[i] * dt/dx *(un[i] - un[i-1]) + nu*dt/dx**2*\
                (un[i+1]-2*un[i]+un[i-1])
```
