### PR TITLE
Display equations correctly

### DIFF
--- a/lessons/09_Step_7.ipynb
+++ b/lessons/09_Step_7.ipynb
@@ -63,10 +63,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\\begin{align}\n",
+    "$$\n",
+    "\\begin{split}\n",
     "u_{i,j}^{n+1} = u_{i,j}^n &+ \\frac{\\nu \\Delta t}{\\Delta x^2}(u_{i+1,j}^n - 2 u_{i,j}^n + u_{i-1,j}^n) \\\\\n",
     "&+ \\frac{\\nu \\Delta t}{\\Delta y^2}(u_{i,j+1}^n-2 u_{i,j}^n + u_{i,j-1}^n)\n",
-    "\\end{align}"
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -115,9 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -149,18 +149,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\\begin{align}\n",
+    "$$\n",
+    "\\begin{split}\n",
     "u_{i,j}^{n+1} = u_{i,j}^n &+ \\frac{\\nu \\Delta t}{\\Delta x^2}(u_{i+1,j}^n - 2 u_{i,j}^n + u_{i-1,j}^n) \\\\\n",
     "&+ \\frac{\\nu \\Delta t}{\\Delta y^2}(u_{i,j+1}^n-2 u_{i,j}^n + u_{i,j-1}^n)\n",
-    "\\end{align}"
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "###Run through nt timesteps\n",
@@ -193,9 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -215,9 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -237,9 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -273,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -308,9 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -440,9 +430,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/lessons/10_Step_8.ipynb
+++ b/lessons/10_Step_8.ipynb
@@ -61,9 +61,11 @@
     "We know how to discretize each term: we've already done it before!\n",
     "\n",
     "$$\n",
-    "\\frac{u_{i,j}^{n+1} - u_{i,j}^n}{\\Delta t} + u_{i,j}^n \\frac{u_{i,j}^n-u_{i-1,j}^n}{\\Delta x} + v_{i,j}^n \\frac{u_{i,j}^n - u_{i,j-1}^n}{\\Delta y} = $$\n",
-    "$$\\qquad \\nu \\bigg( \\frac{u_{i+1,j}^n - 2u_{i,j}^n+u_{i-1,j}^n}{\\Delta x^2} + \\frac{u_{i,j+1}^n - 2u_{i,j}^n + u_{i,j-1}^n}{\\Delta y^2} \\bigg)$$\n",
-    "\n"
+    "\\begin{split}\n",
+    "& \\frac{u_{i,j}^{n+1} - u_{i,j}^n}{\\Delta t} + u_{i,j}^n \\frac{u_{i,j}^n-u_{i-1,j}^n}{\\Delta x} + v_{i,j}^n \\frac{u_{i,j}^n - u_{i,j-1}^n}{\\Delta y} = \\\\\n",
+    "& \\qquad \\nu \\left( \\frac{u_{i+1,j}^n - 2u_{i,j}^n+u_{i-1,j}^n}{\\Delta x^2} + \\frac{u_{i,j+1}^n - 2u_{i,j}^n + u_{i,j-1}^n}{\\Delta y^2} \\right)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -71,8 +73,11 @@
    "metadata": {},
    "source": [
     "$$\n",
-    "\\frac{v_{i,j}^{n+1} - v_{i,j}^n}{\\Delta t} + u_{i,j}^n \\frac{v_{i,j}^n-v_{i-1,j}^n}{\\Delta x} + v_{i,j}^n \\frac{v_{i,j}^n - v_{i,j-1}^n}{\\Delta y} = $$\n",
-    "$$\\nu \\bigg( \\frac{v_{i+1,j}^n - 2v_{i,j}^n+v_{i-1,j}^n}{\\Delta x^2} + \\frac{v_{i,j+1}^n - 2v_{i,j}^n + v_{i,j-1}^n}{\\Delta y^2} \\bigg)$$"
+    "\\begin{split}\n",
+    "& \\frac{v_{i,j}^{n+1} - v_{i,j}^n}{\\Delta t} + u_{i,j}^n \\frac{v_{i,j}^n-v_{i-1,j}^n}{\\Delta x} + v_{i,j}^n \\frac{v_{i,j}^n - v_{i,j-1}^n}{\\Delta y} = \\\\\n",
+    "& \\qquad \\nu \\left( \\frac{v_{i+1,j}^n - 2v_{i,j}^n+v_{i-1,j}^n}{\\Delta x^2} + \\frac{v_{i,j+1}^n - 2v_{i,j}^n + v_{i,j-1}^n}{\\Delta y^2} \\right)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -86,16 +91,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$$u_{i,j}^{n+1} = u_{i,j}^n - \\frac{\\Delta t}{\\Delta x} u_{i,j}^n (u_{i,j}^n - u_{i-1,j}^n) - \\frac{\\Delta t}{\\Delta y} v_{i,j}^n (u_{i,j}^n - u_{i,j-1}^n)+ $$\n",
-    "$$ \\frac{\\nu \\Delta t}{\\Delta x^2}(u_{i+1,j}^n-2u_{i,j}^n+u_{i-1,j}^n) + \\frac{\\nu \\Delta t}{\\Delta y^2} (u_{i,j+1}^n - 2u_{i,j}^n + u_{i,j+1}^n)$$ "
+    "$$\n",
+    "\\begin{split}\n",
+    "u_{i,j}^{n+1} = & u_{i,j}^n - \\frac{\\Delta t}{\\Delta x} u_{i,j}^n (u_{i,j}^n - u_{i-1,j}^n)  - \\frac{\\Delta t}{\\Delta y} v_{i,j}^n (u_{i,j}^n - u_{i,j-1}^n) \\\\\n",
+    "&+ \\frac{\\nu \\Delta t}{\\Delta x^2}(u_{i+1,j}^n-2u_{i,j}^n+u_{i-1,j}^n) + \\frac{\\nu \\Delta t}{\\Delta y^2} (u_{i,j+1}^n - 2u_{i,j}^n + u_{i,j+1}^n)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$$v_{i,j}^{n+1} =  v_{i,j}^n - \\frac{\\Delta t}{\\Delta x} u_{i,j}^n (v_{i,j}^n - v_{i-1,j}^n) - \\frac{\\Delta t}{\\Delta y} v_{i,j}^n (v_{i,j}^n - v_{i,j-1}^n)+ $$\n",
-    "$$ \\frac{\\nu \\Delta t}{\\Delta x^2}(v_{i+1,j}^n-2v_{i,j}^n+v_{i-1,j}^n) + \\frac{\\nu \\Delta t}{\\Delta y^2} (v_{i,j+1}^n - 2v_{i,j}^n + v_{i,j+1}^n)$$ "
+    "$$\n",
+    "\\begin{split}\n",
+    "v_{i,j}^{n+1} = & v_{i,j}^n - \\frac{\\Delta t}{\\Delta x} u_{i,j}^n (v_{i,j}^n - v_{i-1,j}^n) - \\frac{\\Delta t}{\\Delta y} v_{i,j}^n (v_{i,j}^n - v_{i,j-1}^n) \\\\\n",
+    "&+ \\frac{\\nu \\Delta t}{\\Delta x^2}(v_{i+1,j}^n-2v_{i,j}^n+v_{i-1,j}^n) + \\frac{\\nu \\Delta t}{\\Delta y^2} (v_{i,j+1}^n - 2v_{i,j}^n + v_{i,j+1}^n)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -152,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -181,9 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for n in range(nt + 1): ##loop across number of time steps\n",
@@ -224,9 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -266,9 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -301,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -433,9 +436,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/lessons/13_Step_10.ipynb
+++ b/lessons/13_Step_10.ipynb
@@ -29,10 +29,12 @@
    "source": [
     "For a moment, recall the Navier–Stokes equations for an incompressible fluid, where $\\vec{v}$ represents the velocity field:\n",
     "\n",
-    "\\begin{eqnarray}\n",
-    "\\nabla \\cdot\\vec{v} &=& 0\\\\\\\n",
+    "$$\n",
+    "\\begin{eqnarray*}\n",
+    "\\nabla \\cdot\\vec{v} &=& 0 \\\\\n",
     "\\frac{\\partial \\vec{v}}{\\partial t}+(\\vec{v}\\cdot\\nabla)\\vec{v} &=& -\\frac{1}{\\rho}\\nabla p + \\nu \\nabla^2\\vec{v}\n",
-    "\\end{eqnarray}\n",
+    "\\end{eqnarray*}\n",
+    "$$\n",
     "\n",
     "The first equation represents mass conservation at constant density. The second equation is the conservation of momentum. But a problem appears: the continuity equation for incompressble flow does not have a dominant variable and there is no obvious way to couple the velocity and the pressure. In the case of compressible flow, in contrast, mass continuity would provide an evolution equation for the density $\\rho$, which is coupled with an equation of state relating $\\rho$ and $p$.\n",
     "\n",
@@ -403,7 +405,61 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.1"
+  },
+  "nbdime-conflicts": {
+   "local_diff": [
+    {
+     "diff": [
+      {
+       "diff": [
+        {
+         "key": 0,
+         "op": "addrange",
+         "valuelist": [
+          "3.6.5"
+         ]
+        },
+        {
+         "key": 0,
+         "length": 1,
+         "op": "removerange"
+        }
+       ],
+       "key": "version",
+       "op": "patch"
+      }
+     ],
+     "key": "language_info",
+     "op": "patch"
+    }
+   ],
+   "remote_diff": [
+    {
+     "diff": [
+      {
+       "diff": [
+        {
+         "key": 0,
+         "op": "addrange",
+         "valuelist": [
+          "3.6.4"
+         ]
+        },
+        {
+         "key": 0,
+         "length": 1,
+         "op": "removerange"
+        }
+       ],
+       "key": "version",
+       "op": "patch"
+      }
+     ],
+     "key": "language_info",
+     "op": "patch"
+    }
+   ]
   }
  },
  "nbformat": 4,

--- a/lessons/14_Step_11.ipynb
+++ b/lessons/14_Step_11.ipynb
@@ -91,9 +91,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\\begin{eqnarray}\n",
-    "&&\\frac{u_{i,j}^{n+1}-u_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i,j-1}^{n}}{\\Delta y}\\\\\\ \n",
-    "&&=-\\frac{1}{\\rho}\\frac{p_{i+1,j}^{n}-p_{i-1,j}^{n}}{2\\Delta x}+\\nu\\left(\\frac{u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}}{\\Delta x^2}+\\frac{u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}}{\\Delta y^2}\\right)\\end{eqnarray}"
+    "$$\n",
+    "\\begin{split}\n",
+    "& \\frac{u_{i,j}^{n+1}-u_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i,j-1}^{n}}{\\Delta y} = \\\\ \n",
+    "& \\qquad -\\frac{1}{\\rho}\\frac{p_{i+1,j}^{n}-p_{i-1,j}^{n}}{2\\Delta x}+\\nu\\left(\\frac{u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}}{\\Delta x^2}+\\frac{u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}}{\\Delta y^2}\\right)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -107,10 +110,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\\begin{eqnarray}\n",
-    "&&\\frac{v_{i,j}^{n+1}-v_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i,j-1}^{n}}{\\Delta y}\\\\\\\n",
-    "&&=-\\frac{1}{\\rho}\\frac{p_{i,j+1}^{n}-p_{i,j-1}^{n}}{2\\Delta y}\n",
-    "+\\nu\\left(\\frac{v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}}{\\Delta x^2}+\\frac{v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}}{\\Delta y^2}\\right)\\end{eqnarray}"
+    "$$\n",
+    "\\begin{split}\n",
+    "&\\frac{v_{i,j}^{n+1}-v_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i,j-1}^{n}}{\\Delta y} = \\\\\n",
+    "& \\qquad -\\frac{1}{\\rho}\\frac{p_{i,j+1}^{n}-p_{i,j-1}^{n}}{2\\Delta y}\n",
+    "+\\nu\\left(\\frac{v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}}{\\Delta x^2}+\\frac{v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}}{\\Delta y^2}\\right)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -124,12 +130,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$$ \\frac{p_{i+1,j}^{n}-2p_{i,j}^{n}+p_{i-1,j}^{n}}{\\Delta x^2}+\\frac{p_{i,j+1}^{n}-2*p_{i,j}^{n}+p_{i,j-1}^{n}}{\\Delta y^2} \n",
-    "=\\rho\\left[\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)\\right.$$\n",
-    "\n",
-    "$$-\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\n",
-    "- \\ 2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x}\n",
-    "-\\left.\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]\n",
+    "$$\n",
+    "\\begin{split}\n",
+    "& \\frac{p_{i+1,j}^{n}-2p_{i,j}^{n}+p_{i-1,j}^{n}}{\\Delta x^2}+\\frac{p_{i,j+1}^{n}-2p_{i,j}^{n}+p_{i,j-1}^{n}}{\\Delta y^2} = \\\\\n",
+    "& \\qquad \\rho \\left[ \\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right) -\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} - 2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x} - \\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]\n",
+    "\\end{split}\n",
     "$$"
    ]
   },
@@ -149,21 +154,22 @@
     "The momentum equation in the $u$ direction:\n",
     "\n",
     "$$\n",
-    "u_{i,j}^{n+1} = u_{i,j}^{n} - u_{i,j}^{n}\\frac{\\Delta t}{\\Delta x}(u_{i,j}^{n}-u_{i-1,j}^{n})\n",
-    "- v_{i,j}^{n}\\frac{\\Delta t}{\\Delta y}(u_{i,j}^{n}-u_{i,j-1}^{n})$$\n",
-    "$$-\\frac{\\Delta t}{\\rho 2\\Delta x}(p_{i+1,j}^{n}-p_{i-1,j}^{n})\n",
-    "+\\nu\\left(\\frac{\\Delta t}{\\Delta x^2}(u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n})\\right.\n",
-    "+\\left.\\frac{\\Delta t}{\\Delta y^2}(u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n})\\right)\n",
+    "\\begin{split}\n",
+    "u_{i,j}^{n+1} = u_{i,j}^{n} & - u_{i,j}^{n} \\frac{\\Delta t}{\\Delta x} \\left(u_{i,j}^{n}-u_{i-1,j}^{n}\\right) - v_{i,j}^{n} \\frac{\\Delta t}{\\Delta y} \\left(u_{i,j}^{n}-u_{i,j-1}^{n}\\right) \\\\\n",
+    "& - \\frac{\\Delta t}{\\rho 2\\Delta x} \\left(p_{i+1,j}^{n}-p_{i-1,j}^{n}\\right) \\\\\n",
+    "& + \\nu \\left(\\frac{\\Delta t}{\\Delta x^2} \\left(u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}\\right) + \\frac{\\Delta t}{\\Delta y^2} \\left(u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}\\right)\\right)\n",
+    "\\end{split}\n",
     "$$\n",
     "\n",
     "The momentum equation in the $v$ direction:\n",
     "\n",
-    "$$v_{i,j}^{n+1} = v_{i,j}^{n}-u_{i,j}^{n}\\frac{\\Delta t}{\\Delta x}(v_{i,j}^{n}-v_{i-1,j}^{n})\n",
-    "- v_{i,j}^{n}\\frac{\\Delta t}{\\Delta y}(v_{i,j}^{n}-v_{i,j-1}^{n})$$\n",
     "$$\n",
-    "-\\frac{\\Delta t}{\\rho 2\\Delta y}(p_{i,j+1}^{n}-p_{i,j-1}^{n})\n",
-    "+\\nu\\left(\\frac{\\Delta t}{\\Delta x^2}(v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n})\\right.\n",
-    "+\\left.\\frac{\\Delta t}{\\Delta y^2}(v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n})\\right)$$"
+    "\\begin{split}\n",
+    "v_{i,j}^{n+1} = v_{i,j}^{n} & - u_{i,j}^{n} \\frac{\\Delta t}{\\Delta x} \\left(v_{i,j}^{n}-v_{i-1,j}^{n}\\right) - v_{i,j}^{n} \\frac{\\Delta t}{\\Delta y} \\left(v_{i,j}^{n}-v_{i,j-1}^{n})\\right) \\\\\n",
+    "& - \\frac{\\Delta t}{\\rho 2\\Delta y} \\left(p_{i,j+1}^{n}-p_{i,j-1}^{n}\\right) \\\\\n",
+    "& + \\nu \\left(\\frac{\\Delta t}{\\Delta x^2} \\left(v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}\\right) + \\frac{\\Delta t}{\\Delta y^2} \\left(v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}\\right)\\right)\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -173,11 +179,12 @@
     "Almost there! Now, we rearrange the pressure-Poisson equation:\n",
     "\n",
     "$$\n",
-    "p_{i,j}^{n}=\\frac{(p_{i+1,j}^{n}+p_{i-1,j}^{n})\\Delta y^2+(p_{i,j+1}^{n}+p_{i,j-1}^{n})\\Delta x^2}{2(\\Delta x^2+\\Delta y^2)}-\\frac{\\rho\\Delta x^2\\Delta y^2}{2(\\Delta x^2+\\Delta y^2)} \\times$$\n",
-    "\n",
-    "$$\\left[\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)-\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\right. $$\n",
-    "\n",
-    "$$ -2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x}-\\left.\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]$$"
+    "\\begin{split}\n",
+    "p_{i,j}^{n} = & \\frac{\\left(p_{i+1,j}^{n}+p_{i-1,j}^{n}\\right) \\Delta y^2 + \\left(p_{i,j+1}^{n}+p_{i,j-1}^{n}\\right) \\Delta x^2}{2\\left(\\Delta x^2+\\Delta y^2\\right)} \\\\\n",
+    "& -\\frac{\\rho\\Delta x^2\\Delta y^2}{2\\left(\\Delta x^2+\\Delta y^2\\right)} \\\\\n",
+    "& \\times \\left[\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)-\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} -2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x}-\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -653,7 +660,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/lessons/15_Step_12.ipynb
+++ b/lessons/15_Step_12.ipynb
@@ -73,29 +73,32 @@
     "\n",
     "The $u$-momentum equation:\n",
     "\n",
-    "\\begin{eqnarray}\n",
-    "&&\\frac{u_{i,j}^{n+1}-u_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i,j-1}^{n}}{\\Delta y}\\\\\\\n",
-    "&&=-\\frac{1}{\\rho}\\frac{p_{i+1,j}^{n}-p_{i-1,j}^{n}}{2\\Delta x}\\\\\\\n",
-    "&&+\\nu\\left(\\frac{u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}}{\\Delta x^2}+\\frac{u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}}{\\Delta y^2}\\right)+F_{i,j}\n",
-    "\\end{eqnarray}\n",
+    "$$\n",
+    "\\begin{split}\n",
+    "& \\frac{u_{i,j}^{n+1}-u_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{u_{i,j}^{n}-u_{i,j-1}^{n}}{\\Delta y} = \\\\\n",
+    "& \\qquad -\\frac{1}{\\rho}\\frac{p_{i+1,j}^{n}-p_{i-1,j}^{n}}{2\\Delta x} \\\\\n",
+    "& \\qquad +\\nu\\left(\\frac{u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}}{\\Delta x^2}+\\frac{u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}}{\\Delta y^2}\\right)+F_{i,j}\n",
+    "\\end{split}\n",
+    "$$\n",
     "\n",
     "The $v$-momentum equation:\n",
     "\n",
-    "\\begin{eqnarray}\n",
-    "&&\\frac{v_{i,j}^{n+1}-v_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i,j-1}^{n}}{\\Delta y}\\\\\\\n",
-    "&&=-\\frac{1}{\\rho}\\frac{p_{i,j+1}^{n}-p_{i,j-1}^{n}}{2\\Delta y}\\\\\\\n",
-    "&&+\\nu\\left(\\frac{v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}}{\\Delta x^2}+\\frac{v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}}{\\Delta y^2}\\right)\n",
-    "\\end{eqnarray}\n",
+    "$$\n",
+    "\\begin{split}\n",
+    "& \\frac{v_{i,j}^{n+1}-v_{i,j}^{n}}{\\Delta t}+u_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i-1,j}^{n}}{\\Delta x}+v_{i,j}^{n}\\frac{v_{i,j}^{n}-v_{i,j-1}^{n}}{\\Delta y} = \\\\\n",
+    "& \\qquad -\\frac{1}{\\rho}\\frac{p_{i,j+1}^{n}-p_{i,j-1}^{n}}{2\\Delta y} \\\\\n",
+    "& \\qquad +\\nu\\left(\\frac{v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}}{\\Delta x^2}+\\frac{v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}}{\\Delta y^2}\\right)\n",
+    "\\end{split}\n",
+    "$$\n",
     "\n",
     "And the pressure equation:\n",
     "\n",
-    "\\begin{eqnarray}\n",
-    "&&\\frac{p_{i+1,j}^{n}-2p_{i,j}^{n}+p_{i-1,j}^{n}}{\\Delta x^2}+\\frac{p_{i,j+1}^{n}-2*p_{i,j}^{n}+p_{i,j-1}^{n}}{\\Delta y^2}\\\\\\\n",
-    "&&=\\rho\\left(\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)\\right.\\\\\\\n",
-    "&&-\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\\\\\\n",
-    "&&-2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x}\\\\\\\n",
-    "&&-\\left.\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)\n",
-    "\\end{eqnarray}"
+    "$$\n",
+    "\\begin{split}\n",
+    "& \\frac{p_{i+1,j}^{n}-2p_{i,j}^{n}+p_{i-1,j}^{n}}{\\Delta x^2} + \\frac{p_{i,j+1}^{n}-2p_{i,j}^{n}+p_{i,j-1}^{n}}{\\Delta y^2} = \\\\\n",
+    "& \\qquad \\rho\\left[\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right) - \\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} - 2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x} - \\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -106,19 +109,32 @@
     "\n",
     "For the $u$- and $v$ momentum equations, we isolate the velocity at time step `n+1`:\n",
     "\n",
-    "$$u_{i,j}^{n+1} = u_{i,j}^{n} - u_{i,j}^{n}\\frac{\\Delta t}{\\Delta x}(u_{i,j}^{n}-u_{i-1,j}^{n})-v_{i,j}^{n}\\frac{\\Delta t}{\\Delta y}(u_{i,j}^{n}-u_{i,j-1}^{n})$$\n",
-    "$$-\\frac{\\Delta t}{\\rho 2\\Delta x}(p_{i+1,j}^{n}-p_{i-1,j}^{n})+\\nu\\left[\\frac{\\Delta t}{\\Delta x^2}(u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n})\\right.$$\n",
-    "$$+\\left.\\frac{\\Delta t}{\\Delta y^2}(u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n})\\right] + F\\Delta t$$\n",
+    "$$\n",
+    "\\begin{split}\n",
+    "u_{i,j}^{n+1} = u_{i,j}^{n} & - u_{i,j}^{n} \\frac{\\Delta t}{\\Delta x} \\left(u_{i,j}^{n}-u_{i-1,j}^{n}\\right) - v_{i,j}^{n} \\frac{\\Delta t}{\\Delta y} \\left(u_{i,j}^{n}-u_{i,j-1}^{n}\\right) \\\\\n",
+    "& - \\frac{\\Delta t}{\\rho 2\\Delta x} \\left(p_{i+1,j}^{n}-p_{i-1,j}^{n}\\right) \\\\\n",
+    "& + \\nu\\left[\\frac{\\Delta t}{\\Delta x^2} \\left(u_{i+1,j}^{n}-2u_{i,j}^{n}+u_{i-1,j}^{n}\\right) + \\frac{\\Delta t}{\\Delta y^2} \\left(u_{i,j+1}^{n}-2u_{i,j}^{n}+u_{i,j-1}^{n}\\right)\\right] \\\\\n",
+    "& + \\Delta t F\n",
+    "\\end{split}\n",
+    "$$\n",
     "\n",
-    "$$v_{i,j}^{n+1}=v_{i,j}^{n} - u_{i,j}^{n}\\frac{\\Delta t}{\\Delta x}(v_{i,j}^{n}-v_{i-1,j}^{n})-v_{i,j}^{n}\\frac{\\Delta t}{\\Delta y}(v_{i,j}^{n}-v_{i,j-1}^{n})$$\n",
-    "$$-\\frac{\\Delta t}{\\rho 2\\Delta y}(p_{i,j+1}^{n}-p_{i,j-1}^{n})+\\nu\\left[\\frac{\\Delta t}{\\Delta x^2}(v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n})\\right.$$\n",
-    "$$+\\left.\\frac{\\Delta t}{\\Delta y^2}(v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n})\\right]$$\n",
+    "$$\n",
+    "\\begin{split}\n",
+    "v_{i,j}^{n+1} = v_{i,j}^{n} & - u_{i,j}^{n} \\frac{\\Delta t}{\\Delta x} \\left(v_{i,j}^{n}-v_{i-1,j}^{n}\\right) - v_{i,j}^{n} \\frac{\\Delta t}{\\Delta y} \\left(v_{i,j}^{n}-v_{i,j-1}^{n}\\right) \\\\\n",
+    "& - \\frac{\\Delta t}{\\rho 2\\Delta y} \\left(p_{i,j+1}^{n}-p_{i,j-1}^{n}\\right) \\\\\n",
+    "& + \\nu\\left[\\frac{\\Delta t}{\\Delta x^2} \\left(v_{i+1,j}^{n}-2v_{i,j}^{n}+v_{i-1,j}^{n}\\right) + \\frac{\\Delta t}{\\Delta y^2} \\left(v_{i,j+1}^{n}-2v_{i,j}^{n}+v_{i,j-1}^{n}\\right)\\right]\n",
+    "\\end{split}\n",
+    "$$\n",
     "\n",
     "And for the pressure equation, we isolate the term $p_{i,j}^n$ to iterate in pseudo-time:\n",
     "\n",
-    "$$p_{i,j}^{n} = \\frac{(p_{i+1,j}^{n}+p_{i-1,j}^{n})\\Delta y^2+(p_{i,j+1}^{n}+p_{i,j-1}^{n})\\Delta x^2}{2(\\Delta x^2+\\Delta y^2)}-\\frac{\\rho\\Delta x^2\\Delta y^2}{2(\\Delta x^2+\\Delta y^2)}\\times$$\n",
-    "$$\\left[\\frac{1}{\\Delta t}\\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}+\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right)- \\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} \\right.$$\n",
-    "$$- 2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x}-\\left.\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]$$"
+    "$$\n",
+    "\\begin{split}\n",
+    "p_{i,j}^{n} = & \\frac{\\left(p_{i+1,j}^{n}+p_{i-1,j}^{n}\\right) \\Delta y^2 + \\left(p_{i,j+1}^{n}+p_{i,j-1}^{n}\\right) \\Delta x^2}{2(\\Delta x^2+\\Delta y^2)} \\\\\n",
+    "& -\\frac{\\rho\\Delta x^2\\Delta y^2}{2\\left(\\Delta x^2+\\Delta y^2\\right)} \\\\\n",
+    "& \\times \\left[\\frac{1}{\\Delta t} \\left(\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} + \\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right) - \\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x}\\frac{u_{i+1,j}-u_{i-1,j}}{2\\Delta x} - 2\\frac{u_{i,j+1}-u_{i,j-1}}{2\\Delta y}\\frac{v_{i+1,j}-v_{i-1,j}}{2\\Delta x} - \\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\frac{v_{i,j+1}-v_{i,j-1}}{2\\Delta y}\\right]\n",
+    "\\end{split}\n",
+    "$$"
    ]
   },
   {
@@ -141,9 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy\n",
@@ -162,9 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def build_up_b(rho, dt, dx, dy, u, v):\n",
@@ -205,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def pressure_poisson_periodic(p, dx, dy):\n",
@@ -249,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "##variable declarations\n",
@@ -298,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "udiff = 1\n",
@@ -407,9 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -435,9 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -465,9 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -539,9 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -671,9 +669,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Fix #40 

Use Latex split environment.
Remove line breaks to display equation correctly.

You can view the modified notebooks with Nbviewer to check the equations:

* Step 7: [before](https://nbviewer.jupyter.org/github/barbagroup/CFDPython/blob/master/lessons/09_Step_7.ipynb) and [after](https://nbviewer.jupyter.org/github/mesnardo/CFDPython/blob/display-equations/lessons/09_Step_7.ipynb);
* Step 8: [before](https://nbviewer.jupyter.org/github/barbagroup/CFDPython/blob/master/lessons/10_Step_8.ipynb) and [after](https://nbviewer.jupyter.org/github/mesnardo/CFDPython/blob/display-equations/lessons/10_Step_8.ipynb);
* Step 10: [before](https://nbviewer.jupyter.org/github/barbagroup/CFDPython/blob/master/lessons/13_Step_10.ipynb) and [after](https://nbviewer.jupyter.org/github/mesnardo/CFDPython/blob/display-equations/lessons/13_Step_10.ipynb);
* Step 11: [before](https://nbviewer.jupyter.org/github/barbagroup/CFDPython/blob/master/lessons/15_Step_11.ipynb) and [after](https://nbviewer.jupyter.org/github/mesnardo/CFDPython/blob/display-equations/lessons/15_Step_11.ipynb);
* Step 12: [before](https://nbviewer.jupyter.org/github/barbagroup/CFDPython/blob/master/lessons/16_Step_12.ipynb) and [after](https://nbviewer.jupyter.org/github/mesnardo/CFDPython/blob/display-equations/lessons/16_Step_12.ipynb).
